### PR TITLE
Add FastAPI-based SME ERP backend with document-driven inventory

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,166 @@
+# SME ERP Backend (FastAPI)
+
+## 1. 项目目录结构
+```
+backend/
+  app/
+    api/
+      deps.py
+      routers/
+        auth.py
+        customers.py
+        orders.py
+        products.py
+        reports.py
+        stock.py
+        users.py
+    core/
+      config.py
+      constants.py
+      database.py
+      security.py
+    models/
+      base.py
+      customer.py
+      order.py
+      product.py
+      stock.py
+      user.py
+    repositories/
+      customer_repo.py
+      order_repo.py
+      product_repo.py
+      stock_repo.py
+      user_repo.py
+    schemas/
+      auth.py
+      customer.py
+      order.py
+      product.py
+      stock.py
+      user.py
+    services/
+      auth_service.py
+      order_service.py
+      stock_service.py
+    main.py
+  docs/
+    schema.sql
+  requirements.txt
+```
+
+## 2. 数据库表结构（SQL）
+见 `docs/schema.sql`。
+
+## 3. 核心模型
+- User、Product、Customer、SalesOrder、StockBalance、StockDocument、StockLedger
+
+## 4. 关键业务逻辑
+- 下单：`services/order_service.py:create_order`
+- 出库：`services/stock_service.py:stock_out_for_order`
+- 扣库存：`services/stock_service.py` 中使用 `SELECT ... FOR UPDATE` 行级锁
+
+## 5. 示例 API 接口定义
+
+### 登录
+**POST** `/api/v1/auth/login`
+
+Request (form):
+```
+username=admin&password=secret
+```
+Response:
+```
+{
+  "access_token": "<jwt>",
+  "token_type": "bearer"
+}
+```
+
+### 创建客户
+**POST** `/api/v1/customers`
+
+Request:
+```
+{
+  "name": "ACME",
+  "contact_name": "张三",
+  "contact_phone": "13800000000",
+  "address": "深圳市南山区"
+}
+```
+Response:
+```
+{
+  "id": 1,
+  "name": "ACME",
+  "contact_name": "张三",
+  "contact_phone": "13800000000",
+  "address": "深圳市南山区"
+}
+```
+
+### 创建销售订单
+**POST** `/api/v1/orders`
+
+Request:
+```
+{
+  "customer_id": 1,
+  "items": [
+    {"product_id": 1, "quantity": 2, "unit_price": 99.00}
+  ]
+}
+```
+Response:
+```
+{
+  "id": 1,
+  "order_no": "SO20240630120000",
+  "customer_id": 1,
+  "status": "created",
+  "total_amount": 198.00,
+  "items": [
+    {"id": 1, "product_id": 1, "quantity": 2, "unit_price": 99.00, "line_amount": 198.00}
+  ]
+}
+```
+
+### 订单出库
+**POST** `/api/v1/stock/out`
+
+Request:
+```
+{
+  "order_id": 1
+}
+```
+Response:
+```
+{
+  "id": 10,
+  "doc_no": "SO20240630120500",
+  "doc_type": "stock_out",
+  "related_order_id": 1
+}
+```
+
+## 6. 事务与异常处理
+- 关键写操作使用 `with db.begin()` 启动事务。
+- 库存扣减使用 `SELECT ... FOR UPDATE` 行级锁，保证并发安全。
+- 库存不足或单据重复等异常通过 HTTP 400 返回。
+
+## 运行方式
+1. 创建 `.env` 文件：
+```
+DATABASE_URL=mysql+pymysql://user:password@127.0.0.1:3306/erp
+JWT_SECRET_KEY=change-me
+```
+2. 安装依赖：
+```
+pip install -r requirements.txt
+```
+3. 启动服务：
+```
+uvicorn app.main:app --reload
+```

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,40 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.database import SessionLocal
+from app.models.user import User
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.api_v1_prefix}/auth/login")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(
+    db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        user_id = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError as exc:
+        raise credentials_exception from exc
+
+    user = db.get(User, int(user_id))
+    if not user or not user.is_active:
+        raise credentials_exception
+    return user

--- a/backend/app/api/routers/__init__.py
+++ b/backend/app/api/routers/__init__.py
@@ -1,0 +1,3 @@
+from app.api.routers import auth, customers, orders, products, reports, stock, users
+
+__all__ = ["auth", "customers", "orders", "products", "reports", "stock", "users"]

--- a/backend/app/api/routers/auth.py
+++ b/backend/app/api/routers/auth.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.schemas.auth import Token
+from app.services.auth_service import authenticate_user
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/login", response_model=Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    token = authenticate_user(db, form_data.username, form_data.password)
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    return Token(access_token=token)

--- a/backend/app/api/routers/customers.py
+++ b/backend/app/api/routers/customers.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.models.customer import Customer
+from app.models.user import User
+from app.schemas.customer import CustomerCreate, CustomerOut
+from app.repositories import customer_repo
+
+router = APIRouter(prefix="/customers", tags=["customers"])
+
+
+@router.post("", response_model=CustomerOut)
+def create_customer(
+    payload: CustomerCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    customer = Customer(**payload.model_dump(), created_by=user.id)
+    return customer_repo.create(db, customer)
+
+
+@router.get("", response_model=list[CustomerOut])
+def list_customers(db: Session = Depends(get_db), _: User = Depends(get_current_user)):
+    return customer_repo.list_all(db)

--- a/backend/app/api/routers/orders.py
+++ b/backend/app/api/routers/orders.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.models.user import User
+from app.schemas.order import OrderCreate, OrderOut
+from app.services.order_service import create_order
+from app.repositories import order_repo
+
+router = APIRouter(prefix="/orders", tags=["orders"])
+
+
+@router.post("", response_model=OrderOut)
+def create_sales_order(
+    payload: OrderCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    try:
+        with db.begin():
+            order = create_order(
+                db,
+                payload.customer_id,
+                [item.model_dump() for item in payload.items],
+                user.id,
+            )
+        return order
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.get("", response_model=list[OrderOut])
+def list_orders(db: Session = Depends(get_db), _: User = Depends(get_current_user)):
+    return order_repo.list_all(db)

--- a/backend/app/api/routers/products.py
+++ b/backend/app/api/routers/products.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.models.product import Product
+from app.models.user import User
+from app.schemas.product import ProductCreate, ProductOut
+from app.repositories import product_repo
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+@router.post("", response_model=ProductOut)
+def create_product(
+    payload: ProductCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    product = Product(**payload.model_dump(), created_by=user.id)
+    return product_repo.create(db, product)
+
+
+@router.get("", response_model=list[ProductOut])
+def list_products(db: Session = Depends(get_db), _: User = Depends(get_current_user)):
+    return product_repo.list_all(db)

--- a/backend/app/api/routers/reports.py
+++ b/backend/app/api/routers/reports.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.models.order import SalesOrder
+from app.models.stock import StockBalance
+from app.models.user import User
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+
+@router.get("/sales")
+def sales_report(db: Session = Depends(get_db), _: User = Depends(get_current_user)):
+    total_sales = db.scalar(func.coalesce(func.sum(SalesOrder.total_amount), 0))
+    return {"total_sales": float(total_sales)}
+
+
+@router.get("/inventory")
+def inventory_report(db: Session = Depends(get_db), _: User = Depends(get_current_user)):
+    rows = db.query(StockBalance.product_id, StockBalance.quantity).all()
+    return {"items": [{"product_id": row[0], "quantity": row[1]} for row in rows]}

--- a/backend/app/api/routers/stock.py
+++ b/backend/app/api/routers/stock.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.models.user import User
+from app.schemas.stock import StockDocumentOut, StockInCreate, StockOutCreate
+from app.services.stock_service import stock_in, stock_out_for_order
+
+router = APIRouter(prefix="/stock", tags=["stock"])
+
+
+@router.post("/in", response_model=StockDocumentOut)
+def create_stock_in(
+    payload: StockInCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    with db.begin():
+        return stock_in(db, payload.doc_no, [item.model_dump() for item in payload.items], user.id)
+
+
+@router.post("/out", response_model=StockDocumentOut)
+def create_stock_out(
+    payload: StockOutCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    try:
+        with db.begin():
+            return stock_out_for_order(db, payload.order_id, user.id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/backend/app/api/routers/users.py
+++ b/backend/app/api/routers/users.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.core.constants import UserRole
+from app.models.user import User
+from app.schemas.user import UserCreate, UserOut
+from app.services.auth_service import register_user
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def require_admin(user: User = Depends(get_current_user)) -> User:
+    if user.role != UserRole.admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+    return user
+
+
+@router.post("", response_model=UserOut)
+def create_user(
+    payload: UserCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    user = register_user(db, payload.username, payload.full_name, payload.role, payload.password)
+    return user

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,16 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    app_name: str = "SME ERP Backend"
+    api_v1_prefix: str = "/api/v1"
+    jwt_secret_key: str
+    jwt_algorithm: str = "HS256"
+    jwt_access_token_expire_minutes: int = 60
+    database_url: str
+
+    class Config:
+        env_file = ".env"
+
+
+settings = Settings()

--- a/backend/app/core/constants.py
+++ b/backend/app/core/constants.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+
+class UserRole(str, Enum):
+    admin = "admin"
+    staff = "staff"
+
+
+class OrderStatus(str, Enum):
+    created = "created"
+    confirmed = "confirmed"
+    shipped = "shipped"
+    cancelled = "cancelled"
+
+
+class StockDocType(str, Enum):
+    stock_in = "stock_in"
+    stock_out = "stock_out"
+
+
+ORDER_NO_PREFIX = "SO"
+STOCK_OUT_PREFIX = "SO"

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,0 +1,7 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+engine = create_engine(settings.database_url, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+from jose import jwt
+from passlib.context import CryptContext
+
+from app.core.config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(subject: str, expires_minutes: int | None = None) -> str:
+    expire = datetime.utcnow() + timedelta(
+        minutes=expires_minutes or settings.jwt_access_token_expire_minutes
+    )
+    to_encode: Dict[str, Any] = {"sub": subject, "exp": expire}
+    return jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+
+from app.api.routers import auth, customers, orders, products, reports, stock, users
+from app.core.config import settings
+from app.core.database import engine
+from app.models import customer, order, product, stock, user  # noqa: F401
+from app.models.base import Base
+
+app = FastAPI(title=settings.app_name)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+app.include_router(auth.router, prefix=settings.api_v1_prefix)
+app.include_router(users.router, prefix=settings.api_v1_prefix)
+app.include_router(customers.router, prefix=settings.api_v1_prefix)
+app.include_router(products.router, prefix=settings.api_v1_prefix)
+app.include_router(orders.router, prefix=settings.api_v1_prefix)
+app.include_router(stock.router, prefix=settings.api_v1_prefix)
+app.include_router(reports.router, prefix=settings.api_v1_prefix)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,16 @@
+from app.models.customer import Customer
+from app.models.order import SalesOrder, SalesOrderItem
+from app.models.product import Product
+from app.models.stock import StockBalance, StockDocument, StockLedger
+from app.models.user import User
+
+__all__ = [
+    "Customer",
+    "SalesOrder",
+    "SalesOrderItem",
+    "Product",
+    "StockBalance",
+    "StockDocument",
+    "StockLedger",
+    "User",
+]

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/models/customer.py
+++ b/backend/app/models/customer.py
@@ -1,0 +1,15 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Customer(Base):
+    __tablename__ = "customers"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), index=True)
+    contact_name: Mapped[str] = mapped_column(String(50))
+    contact_phone: Mapped[str] = mapped_column(String(30))
+    address: Mapped[str] = mapped_column(String(255))
+    created_by: Mapped[int] = mapped_column(index=True)

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,0 +1,33 @@
+from sqlalchemy import ForeignKey, Numeric, Enum, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.constants import OrderStatus
+from app.models.base import Base
+
+
+class SalesOrder(Base):
+    __tablename__ = "sales_orders"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    order_no: Mapped[str] = mapped_column(String(30), unique=True, index=True)
+    customer_id: Mapped[int] = mapped_column(ForeignKey("customers.id"))
+    status: Mapped[OrderStatus] = mapped_column(Enum(OrderStatus), default=OrderStatus.created)
+    total_amount: Mapped[float] = mapped_column(Numeric(12, 2))
+    created_by: Mapped[int] = mapped_column(index=True)
+
+    items: Mapped[list["SalesOrderItem"]] = relationship(
+        back_populates="order", cascade="all, delete-orphan"
+    )
+
+
+class SalesOrderItem(Base):
+    __tablename__ = "sales_order_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    order_id: Mapped[int] = mapped_column(ForeignKey("sales_orders.id"))
+    product_id: Mapped[int] = mapped_column(ForeignKey("products.id"))
+    quantity: Mapped[int] = mapped_column()
+    unit_price: Mapped[float] = mapped_column(Numeric(12, 2))
+    line_amount: Mapped[float] = mapped_column(Numeric(12, 2))
+
+    order: Mapped[SalesOrder] = relationship(back_populates="items")

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -1,0 +1,14 @@
+from sqlalchemy import String, Numeric
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), index=True)
+    sku: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    unit_price: Mapped[float] = mapped_column(Numeric(12, 2))
+    created_by: Mapped[int] = mapped_column(index=True)

--- a/backend/app/models/stock.py
+++ b/backend/app/models/stock.py
@@ -1,0 +1,36 @@
+from sqlalchemy import ForeignKey, Numeric, Enum, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.constants import StockDocType
+from app.models.base import Base
+
+
+class StockBalance(Base):
+    __tablename__ = "stock_balances"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    product_id: Mapped[int] = mapped_column(ForeignKey("products.id"), unique=True)
+    quantity: Mapped[int] = mapped_column(default=0)
+
+
+class StockDocument(Base):
+    __tablename__ = "stock_documents"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    doc_no: Mapped[str] = mapped_column(String(30), unique=True, index=True)
+    doc_type: Mapped[StockDocType] = mapped_column(Enum(StockDocType))
+    related_order_id: Mapped[int | None] = mapped_column(
+        ForeignKey("sales_orders.id"), nullable=True
+    )
+    created_by: Mapped[int] = mapped_column(index=True)
+
+
+class StockLedger(Base):
+    __tablename__ = "stock_ledgers"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    stock_doc_id: Mapped[int] = mapped_column(ForeignKey("stock_documents.id"))
+    product_id: Mapped[int] = mapped_column(ForeignKey("products.id"))
+    quantity: Mapped[int] = mapped_column()
+    unit_cost: Mapped[float] = mapped_column(Numeric(12, 2))
+    created_by: Mapped[int] = mapped_column(index=True)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,16 @@
+from sqlalchemy import String, Enum
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.constants import UserRole
+from app.models.base import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    full_name: Mapped[str] = mapped_column(String(100))
+    role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.staff)
+    hashed_password: Mapped[str] = mapped_column(String(255))
+    is_active: Mapped[bool] = mapped_column(default=True)

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,9 @@
+from app.repositories import customer_repo, order_repo, product_repo, stock_repo, user_repo
+
+__all__ = [
+    "customer_repo",
+    "order_repo",
+    "product_repo",
+    "stock_repo",
+    "user_repo",
+]

--- a/backend/app/repositories/customer_repo.py
+++ b/backend/app/repositories/customer_repo.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.customer import Customer
+
+
+def create(db: Session, customer: Customer) -> Customer:
+    db.add(customer)
+    db.flush()
+    return customer
+
+
+def list_all(db: Session) -> list[Customer]:
+    return list(db.scalars(select(Customer)))

--- a/backend/app/repositories/order_repo.py
+++ b/backend/app/repositories/order_repo.py
@@ -14,5 +14,10 @@ def get_by_id(db: Session, order_id: int) -> SalesOrder | None:
     return db.scalar(select(SalesOrder).where(SalesOrder.id == order_id))
 
 
+def get_by_id_for_update(db: Session, order_id: int) -> SalesOrder | None:
+    stmt = select(SalesOrder).where(SalesOrder.id == order_id).with_for_update()
+    return db.scalar(stmt)
+
+
 def list_all(db: Session) -> list[SalesOrder]:
     return list(db.scalars(select(SalesOrder)))

--- a/backend/app/repositories/order_repo.py
+++ b/backend/app/repositories/order_repo.py
@@ -1,0 +1,18 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.order import SalesOrder
+
+
+def create(db: Session, order: SalesOrder) -> SalesOrder:
+    db.add(order)
+    db.flush()
+    return order
+
+
+def get_by_id(db: Session, order_id: int) -> SalesOrder | None:
+    return db.scalar(select(SalesOrder).where(SalesOrder.id == order_id))
+
+
+def list_all(db: Session) -> list[SalesOrder]:
+    return list(db.scalars(select(SalesOrder)))

--- a/backend/app/repositories/product_repo.py
+++ b/backend/app/repositories/product_repo.py
@@ -1,0 +1,18 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.product import Product
+
+
+def create(db: Session, product: Product) -> Product:
+    db.add(product)
+    db.flush()
+    return product
+
+
+def list_all(db: Session) -> list[Product]:
+    return list(db.scalars(select(Product)))
+
+
+def get_by_id(db: Session, product_id: int) -> Product | None:
+    return db.scalar(select(Product).where(Product.id == product_id))

--- a/backend/app/repositories/stock_repo.py
+++ b/backend/app/repositories/stock_repo.py
@@ -1,0 +1,27 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.stock import StockBalance, StockDocument, StockLedger
+
+
+def get_balance_for_update(db: Session, product_id: int) -> StockBalance | None:
+    stmt = select(StockBalance).where(StockBalance.product_id == product_id).with_for_update()
+    return db.scalar(stmt)
+
+
+def create_balance(db: Session, balance: StockBalance) -> StockBalance:
+    db.add(balance)
+    db.flush()
+    return balance
+
+
+def create_document(db: Session, doc: StockDocument) -> StockDocument:
+    db.add(doc)
+    db.flush()
+    return doc
+
+
+def create_ledger(db: Session, ledger: StockLedger) -> StockLedger:
+    db.add(ledger)
+    db.flush()
+    return ledger

--- a/backend/app/repositories/user_repo.py
+++ b/backend/app/repositories/user_repo.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+
+
+def get_by_username(db: Session, username: str) -> User | None:
+    return db.scalar(select(User).where(User.username == username))
+
+
+def create(db: Session, user: User) -> User:
+    db.add(user)
+    db.flush()
+    return user

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/backend/app/schemas/customer.py
+++ b/backend/app/schemas/customer.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class CustomerCreate(BaseModel):
+    name: str
+    contact_name: str
+    contact_phone: str
+    address: str
+
+
+class CustomerOut(CustomerCreate):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel, condecimal
+
+from app.core.constants import OrderStatus
+
+
+class OrderItemCreate(BaseModel):
+    product_id: int
+    quantity: int
+    unit_price: condecimal(max_digits=12, decimal_places=2)
+
+
+class OrderCreate(BaseModel):
+    customer_id: int
+    items: list[OrderItemCreate]
+
+
+class OrderItemOut(OrderItemCreate):
+    id: int
+    line_amount: condecimal(max_digits=12, decimal_places=2)
+
+    class Config:
+        from_attributes = True
+
+
+class OrderOut(BaseModel):
+    id: int
+    order_no: str
+    customer_id: int
+    status: OrderStatus
+    total_amount: condecimal(max_digits=12, decimal_places=2)
+    items: list[OrderItemOut]
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, condecimal
+
+
+class ProductCreate(BaseModel):
+    name: str
+    sku: str
+    unit_price: condecimal(max_digits=12, decimal_places=2)
+
+
+class ProductOut(ProductCreate):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/stock.py
+++ b/backend/app/schemas/stock.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, condecimal
+
+from app.core.constants import StockDocType
+
+
+class StockInItem(BaseModel):
+    product_id: int
+    quantity: int
+    unit_cost: condecimal(max_digits=12, decimal_places=2)
+
+
+class StockInCreate(BaseModel):
+    doc_no: str
+    items: list[StockInItem]
+
+
+class StockOutCreate(BaseModel):
+    order_id: int
+
+
+class StockDocumentOut(BaseModel):
+    id: int
+    doc_no: str
+    doc_type: StockDocType
+    related_order_id: int | None
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+
+from app.core.constants import UserRole
+
+
+class UserCreate(BaseModel):
+    username: str
+    full_name: str
+    role: UserRole
+    password: str
+
+
+class UserOut(BaseModel):
+    id: int
+    username: str
+    full_name: str
+    role: UserRole
+    is_active: bool
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,20 @@
+from sqlalchemy.orm import Session
+
+from app.core.security import create_access_token, get_password_hash, verify_password
+from app.models.user import User
+from app.repositories import user_repo
+
+
+def register_user(db: Session, username: str, full_name: str, role: str, password: str) -> User:
+    hashed_password = get_password_hash(password)
+    user = User(username=username, full_name=full_name, role=role, hashed_password=hashed_password)
+    return user_repo.create(db, user)
+
+
+def authenticate_user(db: Session, username: str, password: str) -> str | None:
+    user = user_repo.get_by_username(db, username)
+    if not user or not user.is_active:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return create_access_token(str(user.id))

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from app.core.constants import OrderStatus, ORDER_NO_PREFIX
+from app.models.order import SalesOrder, SalesOrderItem
+from app.repositories import order_repo, product_repo
+
+
+def generate_order_no(prefix: str, now: datetime | None = None) -> str:
+    timestamp = (now or datetime.utcnow()).strftime("%Y%m%d%H%M%S")
+    return f"{prefix}{timestamp}"
+
+
+def create_order(db: Session, customer_id: int, items: list[dict], created_by: int) -> SalesOrder:
+    order_items: list[SalesOrderItem] = []
+    total_amount = Decimal("0.00")
+
+    for item in items:
+        product = product_repo.get_by_id(db, item["product_id"])
+        if not product:
+            raise ValueError("Product not found")
+        line_amount = Decimal(str(item["unit_price"])) * Decimal(item["quantity"])
+        order_items.append(
+            SalesOrderItem(
+                product_id=item["product_id"],
+                quantity=item["quantity"],
+                unit_price=item["unit_price"],
+                line_amount=line_amount,
+            )
+        )
+        total_amount += line_amount
+
+    order = SalesOrder(
+        order_no=generate_order_no(ORDER_NO_PREFIX),
+        customer_id=customer_id,
+        status=OrderStatus.created,
+        total_amount=total_amount,
+        created_by=created_by,
+        items=order_items,
+    )
+    return order_repo.create(db, order)

--- a/backend/app/services/stock_service.py
+++ b/backend/app/services/stock_service.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from app.core.constants import StockDocType, OrderStatus, STOCK_OUT_PREFIX
+from app.models.stock import StockBalance, StockDocument, StockLedger
+from app.repositories import order_repo, stock_repo
+
+
+def generate_stock_doc_no(prefix: str, now: datetime | None = None) -> str:
+    timestamp = (now or datetime.utcnow()).strftime("%Y%m%d%H%M%S")
+    return f"{prefix}{timestamp}"
+
+
+def stock_in(db: Session, doc_no: str, items: list[dict], created_by: int) -> StockDocument:
+    doc = StockDocument(doc_no=doc_no, doc_type=StockDocType.stock_in, created_by=created_by)
+    stock_repo.create_document(db, doc)
+
+    for item in items:
+        balance = stock_repo.get_balance_for_update(db, item["product_id"])
+        if not balance:
+            balance = StockBalance(product_id=item["product_id"], quantity=0)
+            stock_repo.create_balance(db, balance)
+        balance.quantity += item["quantity"]
+        ledger = StockLedger(
+            stock_doc_id=doc.id,
+            product_id=item["product_id"],
+            quantity=item["quantity"],
+            unit_cost=item["unit_cost"],
+            created_by=created_by,
+        )
+        stock_repo.create_ledger(db, ledger)
+
+    return doc
+
+
+def stock_out_for_order(db: Session, order_id: int, created_by: int) -> StockDocument:
+    order = order_repo.get_by_id(db, order_id)
+    if not order:
+        raise ValueError("Order not found")
+    if order.status == OrderStatus.shipped:
+        raise ValueError("Order already shipped")
+
+    doc = StockDocument(
+        doc_no=generate_stock_doc_no(STOCK_OUT_PREFIX),
+        doc_type=StockDocType.stock_out,
+        related_order_id=order.id,
+        created_by=created_by,
+    )
+    stock_repo.create_document(db, doc)
+
+    for item in order.items:
+        balance = stock_repo.get_balance_for_update(db, item.product_id)
+        if not balance:
+            raise ValueError("Stock balance not initialized")
+        if balance.quantity < item.quantity:
+            raise ValueError("Insufficient stock")
+        balance.quantity -= item.quantity
+        ledger = StockLedger(
+            stock_doc_id=doc.id,
+            product_id=item.product_id,
+            quantity=-item.quantity,
+            unit_cost=Decimal(str(item.unit_price)),
+            created_by=created_by,
+        )
+        stock_repo.create_ledger(db, ledger)
+
+    order.status = OrderStatus.shipped
+    return doc

--- a/backend/app/services/stock_service.py
+++ b/backend/app/services/stock_service.py
@@ -36,7 +36,7 @@ def stock_in(db: Session, doc_no: str, items: list[dict], created_by: int) -> St
 
 
 def stock_out_for_order(db: Session, order_id: int, created_by: int) -> StockDocument:
-    order = order_repo.get_by_id(db, order_id)
+    order = order_repo.get_by_id_for_update(db, order_id)
     if not order:
         raise ValueError("Order not found")
     if order.status == OrderStatus.shipped:

--- a/backend/docs/schema.sql
+++ b/backend/docs/schema.sql
@@ -1,0 +1,96 @@
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(50) NOT NULL UNIQUE,
+  full_name VARCHAR(100) NOT NULL,
+  role ENUM('admin', 'staff') NOT NULL DEFAULT 'staff',
+  hashed_password VARCHAR(255) NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE customers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  contact_name VARCHAR(50) NOT NULL,
+  contact_phone VARCHAR(30) NOT NULL,
+  address VARCHAR(255) NOT NULL,
+  created_by INT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_customers_created_by (created_by)
+) ENGINE=InnoDB;
+
+CREATE TABLE products (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  sku VARCHAR(50) NOT NULL UNIQUE,
+  unit_price DECIMAL(12,2) NOT NULL,
+  created_by INT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_products_created_by (created_by)
+) ENGINE=InnoDB;
+
+CREATE TABLE sales_orders (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  order_no VARCHAR(30) NOT NULL UNIQUE,
+  customer_id INT NOT NULL,
+  status ENUM('created', 'confirmed', 'shipped', 'cancelled') NOT NULL DEFAULT 'created',
+  total_amount DECIMAL(12,2) NOT NULL,
+  created_by INT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_sales_orders_customer_id (customer_id),
+  INDEX idx_sales_orders_created_by (created_by),
+  CONSTRAINT fk_sales_orders_customers FOREIGN KEY (customer_id) REFERENCES customers(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE sales_order_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  order_id INT NOT NULL,
+  product_id INT NOT NULL,
+  quantity INT NOT NULL,
+  unit_price DECIMAL(12,2) NOT NULL,
+  line_amount DECIMAL(12,2) NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_sales_order_items_order_id (order_id),
+  CONSTRAINT fk_sales_order_items_orders FOREIGN KEY (order_id) REFERENCES sales_orders(id),
+  CONSTRAINT fk_sales_order_items_products FOREIGN KEY (product_id) REFERENCES products(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE stock_balances (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  product_id INT NOT NULL UNIQUE,
+  quantity INT NOT NULL DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_stock_balances_products FOREIGN KEY (product_id) REFERENCES products(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE stock_documents (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  doc_no VARCHAR(30) NOT NULL UNIQUE,
+  doc_type ENUM('stock_in', 'stock_out') NOT NULL,
+  related_order_id INT NULL,
+  created_by INT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_stock_documents_order_id (related_order_id),
+  CONSTRAINT fk_stock_documents_orders FOREIGN KEY (related_order_id) REFERENCES sales_orders(id)
+) ENGINE=InnoDB;
+
+CREATE TABLE stock_ledgers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  stock_doc_id INT NOT NULL,
+  product_id INT NOT NULL,
+  quantity INT NOT NULL,
+  unit_cost DECIMAL(12,2) NOT NULL,
+  created_by INT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_stock_ledgers_doc_id (stock_doc_id),
+  CONSTRAINT fk_stock_ledgers_docs FOREIGN KEY (stock_doc_id) REFERENCES stock_documents(id),
+  CONSTRAINT fk_stock_ledgers_products FOREIGN KEY (product_id) REFERENCES products(id)
+) ENGINE=InnoDB;

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+SQLAlchemy==2.0.30
+PyMySQL==1.1.1
+pydantic==2.7.4
+pydantic-settings==2.3.4
+python-jose==3.3.0
+passlib[bcrypt]==1.7.4
+python-multipart==0.0.9


### PR DESCRIPTION
### Motivation
- Provide a production-feasible backend for a small/medium enterprise ERP covering users, customers, products, orders and inventory with auditability and concurrency safety. 
- Ensure all inventory changes are driven by documents (no direct stock writes) and that operations are traceable to the operator and timestamp. 
- Use a modern Python stack (`FastAPI`, `SQLAlchemy`, `MySQL`, `JWT`) and a clean layered architecture to make the system extensible and maintainable.

### Description
- Add a FastAPI application entrypoint and automatic table creation on startup in `app/main.py` and configuration in `app/core/config.py`.
- Implement domain models (`User`, `Customer`, `Product`, `SalesOrder`/`SalesOrderItem`, `StockBalance`, `StockDocument`, `StockLedger`) under `app/models/` and provide the MySQL DDL in `docs/schema.sql`.
- Provide layered persistence and lock-aware operations in `app/repositories/` including `get_balance_for_update` which uses `SELECT ... FOR UPDATE` to enforce row-level locking for concurrency safety.
- Implement business logic in `app/services/` including `create_order` and `stock_out_for_order` where orders → stock documents → ledger entries are created inside transactions and status/stock changes are audit-linked to `created_by` and timestamps; constants like `ORDER_NO_PREFIX` are centralized in `app/core/constants.py` to avoid magic values.
- Expose RESTful endpoints in `app/api/routers/` for auth, users, customers, products, orders, stock, and reports; authentication uses JWT and passwords are hashed via `passlib` in `app/core/security.py`.
- Add `backend/README.md` and `backend/requirements.txt` documenting usage, API examples, and run instructions.

### Testing
- No automated tests were executed as part of this change (no CI/test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847c13e30483268b490480f8d60ef7)